### PR TITLE
Arbitrary CPI lint

### DIFF
--- a/lints/arbitrary_cpi/.cargo/config.toml
+++ b/lints/arbitrary_cpi/.cargo/config.toml
@@ -1,0 +1,11 @@
+[target.aarch64-apple-darwin]
+linker = "dylint-link"
+
+[target.x86_64-apple-darwin]
+linker = "dylint-link"
+
+[target.x86_64-unknown-linux-gnu]
+linker = "dylint-link"
+
+[target.x86_64-pc-windows-msvc]
+linker = "dylint-link"

--- a/lints/arbitrary_cpi/.gitignore
+++ b/lints/arbitrary_cpi/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/lints/arbitrary_cpi/Cargo.toml
+++ b/lints/arbitrary_cpi/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "arbitrary_cpi"
+version = "0.1.0"
+authors = ["Andrew Haberlandt (andrew.haberlandt@trailofbits.com)"]
+description = "lint for https://github.com/coral-xyz/sealevel-attacks/tree/master/programs/4-arbitrary-cpi"
+edition = "2018"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[[example]]
+name = "insecure"
+path = "ui/insecure/src/lib.rs"
+
+[[example]]
+name = "recommended"
+path = "ui/recommended/src/lib.rs"
+
+[[example]]
+name = "secure"
+path = "ui/secure/src/lib.rs"
+
+[dependencies]
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "0cb0f7636851f9fcc57085cf80197a2ef6db098f" }
+dylint_linting = "2.0.1"
+if_chain = "1.0.2"
+solana-lints = { path = "../../crate" }
+
+[dev-dependencies]
+anchor-lang = "0.24.2"
+anchor-spl = "0.24.2"
+dylint_testing = "2.0.1"
+spl-token = { version = "3.1.1", features = ["no-entrypoint"] }
+
+[workspace]
+
+[package.metadata.rust-analyzer]
+rustc_private = true

--- a/lints/arbitrary_cpi/README.md
+++ b/lints/arbitrary_cpi/README.md
@@ -1,0 +1,21 @@
+# arbitrary_cpi
+
+**What it does:**
+
+**Why is this bad?**
+
+**Known problems:** When only one enum is serialized, may miss certain edge cases.
+
+**Example:**
+
+```rust
+// example code where a warning is issued
+```
+
+Use instead:
+
+```rust
+// example code that does not raise a warning
+```
+
+Returns true if the `adt` has a field that is an enum and the number of variants of that enum is at least the number of deserialized struct types collected.

--- a/lints/arbitrary_cpi/rust-toolchain
+++ b/lints/arbitrary_cpi/rust-toolchain
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2022-06-30"
+components = ["llvm-tools-preview", "rustc-dev"]

--- a/lints/arbitrary_cpi/src/lib.rs
+++ b/lints/arbitrary_cpi/src/lib.rs
@@ -1,0 +1,353 @@
+#![feature(rustc_private)]
+#![feature(box_patterns)]
+#![warn(unused_extern_crates)]
+
+use if_chain::if_chain;
+use rustc_hir::Body;
+use rustc_lint::{LateContext, LateLintPass};
+
+use rustc_middle::{
+    mir,
+    mir::terminator::TerminatorKind,
+    mir::{BasicBlock, Local, Operand, Place, ProjectionElem, Rvalue, StatementKind},
+    ty::TyKind,
+};
+use rustc_span::symbol::Symbol;
+
+use clippy_utils::{diagnostics::span_lint, match_def_path};
+mod paths;
+
+extern crate rustc_hir;
+extern crate rustc_middle;
+extern crate rustc_span;
+
+dylint_linting::impl_late_lint! {
+    /// **What it does:**
+    /// Finds uses of solana_program::program::invoke that do not check the program_id
+    ///
+    /// **Why is this bad?**
+    /// A contract could call into an attacker-controlled contract instead of the intended one
+    ///
+    /// **Known problems:**
+    /// False positives, since the program_id check may be within some other function (does not
+    /// trace through function calls)
+    /// False negatives, since our analysis is not path-sensitive (the program_id check may not
+    /// occur in all possible execution paths)
+    ///
+    /// **Example:**
+    ///
+    /// ```rust
+    /// // example code where a warning is issued
+    /// let ix = Instruction {
+    ///   program_id: *program_id,
+    ///   accounts: vec![AccountMeta::new_readonly(*program_id, false)],
+    ///   data: vec![0; 16],
+    /// };
+    /// invoke(&ix, accounts.clone());
+    ///
+    /// ```
+    /// Use instead:
+    /// ```rust
+    /// // example code that does not raise a warning
+    /// if (*program_id == ...) {
+    ///     ...
+    /// }
+    /// let ix = Instruction {
+    ///   program_id: *program_id,
+    ///   accounts: vec![AccountMeta::new_readonly(*program_id, false)],
+    ///   data: vec![0; 16],
+    /// };
+    /// invoke(&ix, accounts.clone());
+
+    pub ARBITRARY_CPI,
+    Warn,
+    "Finds unconstrained inter-contract calls",
+    ArbitraryCpi::default()
+}
+
+#[derive(Default)]
+struct ArbitraryCpi {}
+
+impl<'tcx> LateLintPass<'tcx> for ArbitraryCpi {
+    fn check_body(&mut self, cx: &LateContext<'tcx>, body: &'tcx Body<'tcx>) {
+        let hir_map = cx.tcx.hir();
+        let body_did = hir_map.body_owner_def_id(body.id()).to_def_id();
+        if !cx.tcx.def_kind(body_did).is_fn_like() {
+            return;
+        }
+        assert!(cx.tcx.is_mir_available(body_did));
+        let body_mir = cx.tcx.optimized_mir(body_did);
+        let terminators = body_mir
+            .basic_blocks()
+            .iter_enumerated()
+            .map(|(block_id, block)| (block_id, &block.terminator));
+        for (_idx, (block_id, terminator)) in terminators.enumerate() {
+            if_chain! {
+                if let t = terminator.as_ref().unwrap();
+                if let TerminatorKind::Call { func: func_operand, args, destination: _, cleanup: _, .. } = &t.kind;
+                if let mir::Operand::Constant(box func) = func_operand;
+                if let TyKind::FnDef(def_id, _callee_substs) = func.literal.ty().kind();
+                then {
+                    // Static call
+                    let callee_did = *def_id;
+                    if match_def_path(cx, callee_did, &paths::SOLANA_INVOKE) {
+                        let inst_arg = &args[0];
+                        if let Operand::Move(p) = inst_arg {
+                            let (is_whitelist, programid_places) = Self::find_program_id_for_instru(cx, body_mir, block_id, p);
+                            let likely_programid_locals: Vec<Local> = programid_places.iter().map(|pl| pl.local).collect();
+                            if !is_whitelist && !Self::is_programid_checked(cx, body_mir, block_id, likely_programid_locals.as_ref()) {
+                                span_lint(
+                                    cx,
+                                    ARBITRARY_CPI,
+                                    t.source_info.span,
+                                    "program_id may not be checked",
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl ArbitraryCpi {
+    // This function is passed the Place corresponding to the 1st argument to invoke, and is
+    // responsible for tracing the definition of that local back to the point where the instruction
+    // is defined.
+    //
+    // We handle two cases:
+    // 1. The instruction is initialized within this Body, in which case the returned
+    //    likely_program_id_places will contain all the Places containing a program_id,
+    //    and we can then look for comparisions with those places to see if the program id is
+    //    checked.
+    //
+    // 2. The instruction passed to invoke is returned from a function call. In the general case,
+    //    we want to raise a warning since the program ID still might not be checked (the function
+    //    that is called may or may not check it). However, if this came from a call to
+    //    spl_token::instruction::... then it will be checked and we will ignore it
+    //
+    //  Returns (is_whitelisted, likely_program_id_places)
+    fn find_program_id_for_instru<'tcx>(
+        cx: &LateContext,
+        body: &'tcx mir::Body<'tcx>,
+        block: BasicBlock,
+        mut inst_arg: &Place<'tcx>,
+    ) -> (bool, Vec<Place<'tcx>>) {
+        let preds = body.predecessors();
+        let bbs = body.basic_blocks();
+        let mut cur_block = block;
+        let mut found_program_id = false;
+        let mut likely_program_id_aliases = Vec::<Place>::new();
+        loop {
+            // Walk the bb in reverse, starting with the terminator
+            if let Some(t) = &bbs[cur_block].terminator {
+                match &t.kind {
+                    TerminatorKind::Call {
+                        func: mir::Operand::Constant(box func),
+                        destination: dest,
+                        args,
+                        ..
+                    } if dest.local_or_deref_local() == Some(inst_arg.local)
+                        && !found_program_id =>
+                    {
+                        if_chain! {
+                            if let TyKind::FnDef(def_id, _callee_substs) = func.literal.ty().kind();
+                            if let Operand::Copy(arg0_pl) | Operand::Move(arg0_pl) = &args[0];
+                            then {
+                                // in order to trace back to the call which creates the
+                                // instruction, we have to trace through a call to Try::branch
+                                if match_def_path(cx, *def_id, &paths::TRY_BRANCH) {
+                                    inst_arg = arg0_pl;
+                                } else {
+                                    let path = cx.get_def_path(*def_id);
+                                    let token_path = paths::SPL_TOKEN.map(Symbol::intern);
+                                    if path.iter().take(2).eq(&token_path) {
+                                        return (true, likely_program_id_aliases)
+                                    }
+                                }
+
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            // check every statement
+            for stmt in bbs[cur_block].statements.iter().rev() {
+                match &stmt.kind {
+                    StatementKind::Assign(box (assign_place, rvalue))
+                        if assign_place.local_or_deref_local()
+                            == inst_arg.local_or_deref_local() =>
+                    {
+                        match rvalue {
+                            Rvalue::Use(
+                                Operand::Copy(rvalue_place) | Operand::Move(rvalue_place),
+                            ) => {
+                                // println!("Found assignment {:?}", stmt);
+                                inst_arg = rvalue_place;
+                                if found_program_id {
+                                    likely_program_id_aliases.push(*rvalue_place);
+                                }
+                            }
+                            Rvalue::Ref(_, _, pl) => {
+                                // println!("Found assignment (ref) {:?}", pl);
+                                inst_arg = pl;
+                                if found_program_id {
+                                    likely_program_id_aliases.push(*inst_arg);
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    StatementKind::Assign(box (assign_place, rvalue))
+                        if assign_place.local == inst_arg.local =>
+                    {
+                        if_chain! {
+                            // If we've found the Instruction that was passed to invoke, then
+                            // field at index 0 will be the program_id
+                            if assign_place.projection.len() == 1;
+                            if let proj = assign_place.projection[0];
+                            if let ProjectionElem::Field(f, ty) = proj;
+                            if f.index() == 0;
+                            if let Some(adtdef) = ty.ty_adt_def();
+                            if match_def_path(cx, adtdef.did(), &["solana_program", "pubkey", "Pubkey"]);
+                            then {
+                                // We found the field
+                                if let Rvalue::Use(Operand::Copy(pl) | Operand::Move(pl)) | Rvalue::Ref(_, _, pl) = rvalue {
+                                    inst_arg = pl;
+                                    likely_program_id_aliases.push(*pl);
+                                    // println!("Found program ID: {:?}", rvalue);
+                                    found_program_id = true;
+                                    break
+                                }
+
+                            }
+                        };
+                    }
+                    _ => {}
+                }
+            }
+            match preds.get(cur_block) {
+                Some(cur_preds) if !cur_preds.is_empty() => cur_block = cur_preds[0],
+                _ => {
+                    break;
+                }
+            }
+        }
+        // println!("Likely aliases: {:?}", likely_program_id_aliases);
+        (false, likely_program_id_aliases)
+    }
+
+    // helper function
+    // Given the Place search_place, check if it was defined using one of the locals in search_list
+    fn is_moved_from<'tcx>(
+        _: &LateContext,
+        body: &'tcx mir::Body<'tcx>,
+        block: BasicBlock,
+        mut search_place: &Place<'tcx>,
+        search_list: &[Local],
+    ) -> bool {
+        let preds = body.predecessors();
+        let bbs = body.basic_blocks();
+        let mut cur_block = block;
+        if let Some(search_loc) = search_place.local_or_deref_local() {
+            if search_list.contains(&search_loc) {
+                return true;
+            }
+        }
+        loop {
+            for stmt in bbs[cur_block].statements.iter().rev() {
+                match &stmt.kind {
+                    StatementKind::Assign(box (assign_place, rvalue))
+                        if assign_place.local_or_deref_local()
+                            == search_place.local_or_deref_local() =>
+                    {
+                        match rvalue {
+                            Rvalue::Use(
+                                Operand::Copy(rvalue_place) | Operand::Move(rvalue_place),
+                            )
+                            | Rvalue::Ref(_, _, rvalue_place) => {
+                                // println!("Found assignment {:?}", stmt);
+                                search_place = rvalue_place;
+                                if let Some(search_loc) = search_place.local_or_deref_local() {
+                                    if search_list.contains(&search_loc) {
+                                        return true;
+                                    }
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            match preds.get(cur_block) {
+                Some(cur_preds) if !cur_preds.is_empty() => cur_block = cur_preds[0],
+                _ => {
+                    break;
+                }
+            }
+        }
+        false
+    }
+
+    // This function takes the list of programid_locals and a starting block, and searches for a
+    // check elsewhere in the Body that would compare the program_id with something else.
+    fn is_programid_checked<'tcx>(
+        cx: &LateContext,
+        body: &'tcx mir::Body<'tcx>,
+        block: BasicBlock,
+        programid_locals: &[Local],
+    ) -> bool {
+        let preds = body.predecessors();
+        let bbs = body.basic_blocks();
+        let mut cur_block = block;
+        loop {
+            // check every statement
+            if_chain! {
+                if let Some(t) = &bbs[cur_block].terminator;
+                if let TerminatorKind::Call { func: func_operand, args, destination: _, cleanup: _, .. } = &t.kind;
+                if let mir::Operand::Constant(box func) = func_operand;
+                if let TyKind::FnDef(def_id, _callee_substs) = func.literal.ty().kind();
+                if match_def_path(cx, *def_id, &["core", "cmp", "PartialEq", "ne"]) || match_def_path(cx, *def_id, &["core", "cmp", "PartialEq", "eq"]);
+                if let Operand::Copy(arg0_pl) | Operand::Move(arg0_pl) = args[0];
+                if let Operand::Copy(arg1_pl) | Operand::Move(arg1_pl) = args[1];
+                // if let Some(arg0) = arg0_pl.local_or_deref_local();
+                // if let Some(arg1) = arg1_pl.local_or_deref_local();
+                then {
+                    // if either arg0 or arg1 came from one of the programid_locals, then we know
+                    // this eq/ne check was operating on the program_id.
+                    if Self::is_moved_from(cx, body, cur_block, &arg0_pl, programid_locals) || Self::is_moved_from(cx, body, cur_block, &arg1_pl, programid_locals) {
+                        // we found the check. if it dominates the call to invoke, then the check
+                        // is assumed to be sufficient!
+                        return body.dominators().is_dominated_by(block, cur_block);
+                    }
+                }
+            }
+
+            match preds.get(cur_block) {
+                Some(cur_preds) if !cur_preds.is_empty() => cur_block = cur_preds[0],
+                _ => {
+                    break;
+                }
+            }
+        }
+        false
+    }
+}
+
+#[test]
+fn insecure() {
+    dylint_testing::ui_test_example(env!("CARGO_PKG_NAME"), "insecure");
+}
+
+#[test]
+fn secure() {
+    dylint_testing::ui_test_example(env!("CARGO_PKG_NAME"), "secure");
+}
+
+#[test]
+fn recommended() {
+    dylint_testing::ui_test_example(env!("CARGO_PKG_NAME"), "recommended");
+}

--- a/lints/arbitrary_cpi/src/paths.rs
+++ b/lints/arbitrary_cpi/src/paths.rs
@@ -1,0 +1,3 @@
+pub const SOLANA_INVOKE: [&str; 3] = ["solana_program", "program", "invoke"];
+pub const SPL_TOKEN: [&str; 2] = ["spl_token", "instruction"];
+pub const TRY_BRANCH: [&str; 5] = ["core", "ops", "try_trait", "Try", "branch"];

--- a/lints/arbitrary_cpi/ui/insecure/Cargo.toml
+++ b/lints/arbitrary_cpi/ui/insecure/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "arbitrary-cpi-insecure"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "arbitrary_cpi_insecure"
+
+[features]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+cpi = ["no-entrypoint"]
+default = []
+
+[dependencies]
+anchor-lang = "0.20.1"
+anchor-spl = "0.20.1"
+spl-token = { version = "3.1.1", features = ["no-entrypoint"] }

--- a/lints/arbitrary_cpi/ui/insecure/Xargo.toml
+++ b/lints/arbitrary_cpi/ui/insecure/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/lints/arbitrary_cpi/ui/insecure/src/lib.rs
+++ b/lints/arbitrary_cpi/ui/insecure/src/lib.rs
@@ -1,0 +1,37 @@
+use crate::solana_program::entrypoint::ProgramResult;
+use crate::solana_program::instruction::Instruction;
+use anchor_lang::prelude::*;
+use anchor_lang::solana_program;
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+#[program]
+pub mod arbitrary_cpi_insecure {
+    use super::*;
+
+    pub fn cpi(ctx: Context<Cpi>, amount: u64) -> ProgramResult {
+        let ins = Instruction {
+            program_id: *ctx.accounts.token_program.key,
+            accounts: vec![],
+            data: vec![],
+        };
+        solana_program::program::invoke(
+            &ins,
+            &[
+                ctx.accounts.source.clone(),
+                ctx.accounts.destination.clone(),
+                ctx.accounts.authority.clone(),
+            ],
+        )
+    }
+}
+
+#[derive(Accounts)]
+pub struct Cpi<'info> {
+    source: AccountInfo<'info>,
+    destination: AccountInfo<'info>,
+    authority: AccountInfo<'info>,
+    token_program: AccountInfo<'info>,
+}
+
+fn main() {}

--- a/lints/arbitrary_cpi/ui/insecure/src/lib.stderr
+++ b/lints/arbitrary_cpi/ui/insecure/src/lib.stderr
@@ -1,0 +1,16 @@
+error: program_id may not be checked
+  --> $DIR/lib.rs:18:9
+   |
+LL | /         solana_program::program::invoke(
+LL | |             &ins,
+LL | |             &[
+LL | |                 ctx.accounts.source.clone(),
+...  |
+LL | |             ],
+LL | |         )
+   | |_________^
+   |
+   = note: `-D arbitrary-cpi` implied by `-D warnings`
+
+error: aborting due to previous error
+

--- a/lints/arbitrary_cpi/ui/recommended/Cargo.toml
+++ b/lints/arbitrary_cpi/ui/recommended/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "arbitrary-cpi-recommended"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "arbitrary_cpi_recommended"
+
+[features]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+cpi = ["no-entrypoint"]
+default = []
+
+[dependencies]
+anchor-lang = "0.20.1"
+anchor-spl = "0.20.1"
+spl-token = { version = "3.1.1", features = ["no-entrypoint"] }

--- a/lints/arbitrary_cpi/ui/recommended/Xargo.toml
+++ b/lints/arbitrary_cpi/ui/recommended/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/lints/arbitrary_cpi/ui/recommended/src/lib.rs
+++ b/lints/arbitrary_cpi/ui/recommended/src/lib.rs
@@ -1,0 +1,35 @@
+use anchor_lang::prelude::*;
+use anchor_spl::token::{self, Token, TokenAccount};
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+#[program]
+pub mod arbitrary_cpi_recommended {
+    use super::*;
+
+    pub fn cpi(ctx: Context<Cpi>, amount: u64) -> Result<()> {
+        token::transfer(ctx.accounts.transfer_ctx(), amount)
+    }
+}
+
+#[derive(Accounts)]
+pub struct Cpi<'info> {
+    source: Account<'info, TokenAccount>,
+    destination: Account<'info, TokenAccount>,
+    authority: Signer<'info>,
+    token_program: Program<'info, Token>,
+}
+
+impl<'info> Cpi<'info> {
+    pub fn transfer_ctx(&self) -> CpiContext<'_, '_, '_, 'info, token::Transfer<'info>> {
+        let program = self.token_program.to_account_info();
+        let accounts = token::Transfer {
+            from: self.source.to_account_info(),
+            to: self.destination.to_account_info(),
+            authority: self.authority.to_account_info(),
+        };
+        CpiContext::new(program, accounts)
+    }
+}
+
+fn main() {}

--- a/lints/arbitrary_cpi/ui/secure/Cargo.toml
+++ b/lints/arbitrary_cpi/ui/secure/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "arbitrary-cpi-secure"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "arbitrary_cpi_secure"
+
+[features]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+cpi = ["no-entrypoint"]
+default = []
+
+[dependencies]
+anchor-lang = "0.20.1"
+anchor-spl = "0.20.1"
+spl-token = { version = "3.1.1", features = ["no-entrypoint"] }

--- a/lints/arbitrary_cpi/ui/secure/Xargo.toml
+++ b/lints/arbitrary_cpi/ui/secure/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/lints/arbitrary_cpi/ui/secure/src/lib.rs
+++ b/lints/arbitrary_cpi/ui/secure/src/lib.rs
@@ -1,0 +1,41 @@
+use crate::solana_program::entrypoint::ProgramResult;
+use anchor_lang::prelude::*;
+use anchor_lang::solana_program;
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+#[program]
+pub mod arbitrary_cpi_secure {
+    use super::*;
+
+    pub fn cpi_secure(ctx: Context<Cpi>, amount: u64) -> ProgramResult {
+        if &spl_token::ID != ctx.accounts.token_program.key {
+            return Err(ProgramError::IncorrectProgramId);
+        }
+        solana_program::program::invoke(
+            &spl_token::instruction::transfer(
+                ctx.accounts.token_program.key,
+                ctx.accounts.source.key,
+                ctx.accounts.destination.key,
+                ctx.accounts.authority.key,
+                &[],
+                amount,
+            )?,
+            &[
+                ctx.accounts.source.clone(),
+                ctx.accounts.destination.clone(),
+                ctx.accounts.authority.clone(),
+            ],
+        )
+    }
+}
+
+#[derive(Accounts)]
+pub struct Cpi<'info> {
+    source: AccountInfo<'info>,
+    destination: AccountInfo<'info>,
+    authority: AccountInfo<'info>,
+    token_program: AccountInfo<'info>,
+}
+
+fn main() {}


### PR DESCRIPTION
note: this (incorrectly) flags the 'secure' example because the Instruction structure is returned from another function, so the analysis cannot find where the 'program_id' member of the Instruction structure is initialized.