### PR TITLE
Fix missing_owner_check lint

### DIFF
--- a/crate/src/paths.rs
+++ b/crate/src/paths.rs
@@ -3,6 +3,7 @@
 // all in upper snake case.
 
 pub const ANCHOR_LANG_ACCOUNT: [&str; 4] = ["anchor_lang", "accounts", "account", "Account"];
+pub const ANCHOR_LANG_ACCOUNT_LOADER: [&str; 4] = ["anchor_lang", "accounts", "account_loader", "AccountLoader"];
 pub const ANCHOR_LANG_PROGRAM: [&str; 4] = ["anchor_lang", "accounts", "program", "Program"];
 pub const ANCHOR_LANG_SYSTEM_ACCOUNT: [&str; 4] =
     ["anchor_lang", "accounts", "system_account", "SystemAccount"];
@@ -10,6 +11,7 @@ pub const ANCHOR_LANG_ACCOUNT_DESERIALIZE: [&str; 2] = ["anchor_lang", "AccountD
 pub const ANCHOR_LANG_CONTEXT: [&str; 3] = ["anchor_lang", "context", "Context"];
 pub const ANCHOR_LANG_DISCRIMINATOR: [&str; 2] = ["anchor_lang", "Discriminator"];
 pub const ANCHOR_LANG_SIGNER: [&str; 4] = ["anchor_lang", "accounts", "signer", "Signer"];
+pub const ANCHOR_LANG_SYSVAR: [&str; 4] = ["anchor_lang", "accounts", "sysvar", "Sysvar"];
 pub const ANCHOR_LANG_TO_ACCOUNT_INFO: [&str; 3] =
     ["anchor_lang", "ToAccountInfo", "to_account_info"];
 pub const ANCHOR_LANG_TRY_DESERIALIZE: [&str; 3] =
@@ -18,6 +20,7 @@ pub const ANCHOR_LANG_TRY_DESERIALIZE: [&str; 3] =
 pub const BORSH_TRY_FROM_SLICE: [&str; 4] = ["borsh", "de", "BorshDeserialize", "try_from_slice"];
 
 pub const CORE_BRANCH: [&str; 5] = ["core", "ops", "try_trait", "Try", "branch"];
+pub const CORE_CLONE: [&str; 4] = ["core", "clone", "Clone", "clone"];
 
 pub const SOLANA_PROGRAM_ACCOUNT_INFO: [&str; 3] =
     ["solana_program", "account_info", "AccountInfo"];


### PR DESCRIPTION
Updates the lint to ignore `Signer`, `AccountLoader` and `Sysvar` account types.

For expressions of type `x.clone()` where x is AccountInfo, lint considers both expressions `x` and `x.clone()` to refer to different accounts and expects the developers to perform the owner check using `x` expression and `x.clone()` expression. As both refer to same account, the lint is updated to ignore `clone()` expressions from checking.