### PR TITLE
Update missing-owner-check lint to ignore if the key of the account is compared

### DIFF
--- a/crate/src/paths.rs
+++ b/crate/src/paths.rs
@@ -17,6 +17,8 @@ pub const ANCHOR_LANG_TO_ACCOUNT_INFO: [&str; 3] =
     ["anchor_lang", "ToAccountInfo", "to_account_info"];
 pub const ANCHOR_LANG_TRY_DESERIALIZE: [&str; 3] =
     ["anchor_lang", "AccountDeserialize", "try_deserialize"];
+// key() method call path
+pub const ANCHOR_LANG_KEY: [&str; 3] = ["anchor_lang", "Key", "key"];
 
 pub const BORSH_TRY_FROM_SLICE: [&str; 4] = ["borsh", "de", "BorshDeserialize", "try_from_slice"];
 


### PR DESCRIPTION
The PR updates the lint to check if key of account is compared against some value. if the key is compared then the account is ignored by the lint and is not reported.

The update to the lint is as follows:

Given list of `account_expr` where each `account_expr` returns AccountInfo

1. For each `account_expr`
2. Walk through each expression in the body of the function
3. Check if the expression is a comparison: `==` or `!=`
4. Check if lhs or rhs of the comparison accesses the key on the `account_expr`
    - The key could be accessed using `.key()` for Anchor and `.key` for Solana AccountInfo.
    - Check if the expression is a method call to `.key()` or is a field access expression accessing `.key`.

The PR also makes some of the functions generic and removes redundant code. 