### PR TITLE
Update missing-owner-check lint to consider anchor constraints applied on the accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 /lints/*/ui/*/Cargo.lock
+# /lints/debug/*
+/lints/*/ui/Cargo.toml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 /target
 /lints/*/ui/*/Cargo.lock
-# /lints/debug/*
-/lints/*/ui/Cargo.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "anchor-syn"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9101b84702fed2ea57bd22992f75065da5648017135b844283a2f6d74f27825"
+dependencies = [
+ "anyhow",
+ "bs58",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "syn 1.0.109",
+ "thiserror",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anyhow"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "assert_cmd"
@@ -43,6 +73,24 @@ name = "bitflags"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5353f36341f7451062466f0b755b96ac3a9547e4d7f6b70d603fc721a7d7896"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "bstr"
@@ -73,6 +121,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clippy_config"
+version = "0.1.77"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=ac4c2094a6030530661bee3876e0228ddfeb6b8b#ac4c2094a6030530661bee3876e0228ddfeb6b8b"
+dependencies = [
+ "rustc-semver",
+ "serde",
+ "toml 0.7.8",
+]
+
+[[package]]
+name = "clippy_utils"
+version = "0.1.77"
+source = "git+https://github.com/rust-lang/rust-clippy?rev=ac4c2094a6030530661bee3876e0228ddfeb6b8b#ac4c2094a6030530661bee3876e0228ddfeb6b8b"
+dependencies = [
+ "arrayvec",
+ "clippy_config",
+ "itertools",
+ "rustc-semver",
+]
+
+[[package]]
 name = "console"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,16 +154,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "either"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "encode_unicode"
@@ -134,10 +238,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "if_chain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "indexmap"
@@ -148,6 +277,21 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "lazy_static"
@@ -272,6 +416,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "rustc-semver"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be1bdc7edf596692617627bbfeaba522131b18e06ca4df2b6b689e3c5d5ce84"
+
+[[package]]
 name = "rustix"
 version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +433,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "serde"
@@ -301,7 +457,18 @@ checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -311,6 +478,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -337,11 +515,26 @@ dependencies = [
 name = "solana-lints"
 version = "0.1.0"
 dependencies = [
+ "anchor-syn",
  "assert_cmd",
+ "clippy_utils",
+ "if_chain",
  "predicates",
  "similar-asserts",
+ "syn 1.0.109",
  "tempfile",
- "toml",
+ "toml 0.8.10",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -374,6 +567,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
+name = "thiserror"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,7 +622,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.22.4",
 ]
 
 [[package]]
@@ -392,6 +632,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -408,6 +661,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +677,12 @@ name = "unicode-segmentation"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wait-timeout"

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anchor-syn = "0.29.0"
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "ac4c2094a6030530661bee3876e0228ddfeb6b8b" }
+if_chain = "1.0"
+syn = { version = "1.0.109", features = ["parsing"] }
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/crate/diffs/missing_owner_check.diff
+++ b/crate/diffs/missing_owner_check.diff
@@ -62,5 +62,6 @@ diff -r -x Cargo.lock ./secure/src/lib.rs ../../../../lints/missing_owner_check/
 > fn main() {}
 Only in ../../../../lints/missing_owner_check/ui/secure/src: lib.stderr
 Only in ../../../../lints/missing_owner_check/ui: secure-account-owner
+Only in ../../../../lints/missing_owner_check/ui: secure-anchor-constraints
 Only in ../../../../lints/missing_owner_check/ui: secure-fixed
 Only in ../../../../lints/missing_owner_check/ui: secure-program-id

--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -2,6 +2,8 @@
 #![warn(unused_extern_crates)]
 
 extern crate rustc_hir;
+extern crate rustc_lint;
+extern crate rustc_middle;
 
 #[allow(unused_extern_crates)]
 extern crate rustc_driver;

--- a/crate/src/paths.rs
+++ b/crate/src/paths.rs
@@ -19,6 +19,7 @@ pub const ANCHOR_LANG_TRY_DESERIALIZE: [&str; 3] =
     ["anchor_lang", "AccountDeserialize", "try_deserialize"];
 // key() method call path
 pub const ANCHOR_LANG_KEY: [&str; 3] = ["anchor_lang", "Key", "key"];
+pub const ANCHOR_LANG_TO_ACCOUNT_INFOS_TRAIT: [&str; 2] = ["anchor_lang", "ToAccountInfos"];
 
 pub const BORSH_TRY_FROM_SLICE: [&str; 4] = ["borsh", "de", "BorshDeserialize", "try_from_slice"];
 

--- a/crate/src/utils.rs
+++ b/crate/src/utils.rs
@@ -1,7 +1,16 @@
+use anchor_syn::parser::accounts as accounts_parser;
+use anchor_syn::AccountsStruct;
+use clippy_utils::{get_trait_def_id, ty::implements_trait};
+use if_chain::if_chain;
 use rustc_hir::{
     intravisit::{walk_expr, Visitor},
-    Expr,
+    Expr, Item, ItemKind,
 };
+use rustc_lint::LateContext;
+use rustc_middle::ty::{self, GenericArgKind};
+use syn::{parse_str, ItemStruct};
+
+use crate::paths;
 
 pub trait Conclusive: Default {
     fn concluded(&self) -> bool;
@@ -51,6 +60,56 @@ where
             if !self.result.concluded() {
                 walk_expr(self, expr);
             }
+        }
+    }
+}
+
+/// Return `Some(accounts_struct)` if the item is an Anchor Accounts struct derived using `#[derive(Accounts)]` macro else None
+/// - If Item is a Struct and implements `anchor_lang::ToAccountInfos` trait.
+///     - Get the pre-expansion source code and parse it using anchor's accounts parser
+///     - If parsing succeeds then
+///         - Return `Some(anchor_syn::AccountsStruct)`
+///     - Else return None
+/// - Else return None
+pub fn get_anchor_accounts_struct<'tcx>(
+    cx: &LateContext<'tcx>,
+    item: &'tcx Item<'tcx>,
+) -> Option<AccountsStruct> {
+    // identify Anchor structs:
+    // `#[derive(Accounts)]` macro implements `anchor_lang::ToAccountInfos` trait for the struct
+    if_chain! {
+        // Anchor generated IDL structs also implement these traits. Check if the item is defined in this crate.
+        if !item.span.from_expansion();
+        if let ItemKind::Struct(_, _) = item.kind;
+        // Accounts structs implement `anchor_lang::ToAccountInfos` trait.
+        // see: https://github.com/coral-xyz/anchor/blob/8eee184938f71e3b85414d469db55fd882b380b2/lang/syn/src/codegen/accounts/mod.rs#L19
+        if let Some(trait_id) = get_trait_def_id(cx, &paths::ANCHOR_LANG_TO_ACCOUNT_INFOS_TRAIT);
+        // `implements_trait` takes generic arguments. providing empty args or dummy args works fine outside tests but
+        // fails in tests because of a debug assertion. ToAccountInfos is used instead of Accounts trait because Accounts trait
+        // takes a type generic argument. It is not possible to find the generic args in `check_item`, have to use `check_impl` probably.
+        // Assumption: Accounts structs have a lifetime argument and it should be same for the trait implementations as well.
+        if let ty::Adt(_, substs) = cx
+            .tcx
+            .type_of(item.owner_id.to_def_id())
+            .skip_binder()
+            .kind();
+        if let Some(lifetime_arg) = substs
+            .iter()
+            .find(|arg| matches!(arg.unpack(), GenericArgKind::Lifetime(_)));
+        if implements_trait(
+            cx,
+            cx.tcx.type_of(item.owner_id.to_def_id()).skip_binder(),
+            trait_id,
+            &[lifetime_arg],
+        );
+        // Get the pre-expansion source code of the struct and parse it using anchor's parser.
+        if let Ok(struct_str) = cx.tcx.sess.source_map().span_to_snippet(item.span);
+        if let Ok(syn_struct) = parse_str::<ItemStruct>(&struct_str);
+        if let Ok(accounts_struct) = accounts_parser::parse(&syn_struct);
+        then {
+            Some(accounts_struct)
+        } else {
+            None
         }
     }
 }

--- a/crate/tests/lints.rs
+++ b/crate/tests/lints.rs
@@ -11,7 +11,7 @@ fn lints() {
         .join("..")
         .join("lints");
 
-    for entry in read_dir(dir).unwrap() {
+    for (index, entry) in read_dir(dir).unwrap().enumerate() {
         let entry = entry.unwrap();
         let path = entry.path();
 
@@ -19,9 +19,18 @@ fn lints() {
         writeln!(stderr(), "{:?}", path.canonicalize().unwrap()).unwrap();
 
         std::process::Command::new("cargo")
+            .current_dir(path.clone())
+            .env_remove("RUSTUP_TOOLCHAIN")
+            .env("CARGO_TARGET_DIR", format!("target_{index}"))
+            .args(["test"])
+            .assert()
+            .success();
+
+        std::process::Command::new("cargo")
             .current_dir(path)
             .env_remove("RUSTUP_TOOLCHAIN")
-            .args(["test"])
+            .env("CARGO_TARGET_DIR", format!("target_{index}"))
+            .args(["clean"])
             .assert()
             .success();
     }

--- a/lints/arbitrary_cpi/Cargo.lock
+++ b/lints/arbitrary_cpi/Cargo.lock
@@ -2413,6 +2413,12 @@ dependencies = [
 [[package]]
 name = "solana-lints"
 version = "0.1.0"
+dependencies = [
+ "anchor-syn",
+ "clippy_utils",
+ "if_chain",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "solana-logger"

--- a/lints/bump_seed_canonicalization/Cargo.lock
+++ b/lints/bump_seed_canonicalization/Cargo.lock
@@ -2073,6 +2073,12 @@ dependencies = [
 [[package]]
 name = "solana-lints"
 version = "0.1.0"
+dependencies = [
+ "anchor-syn",
+ "clippy_utils",
+ "if_chain",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "solana-program"

--- a/lints/insecure_account_close/Cargo.lock
+++ b/lints/insecure_account_close/Cargo.lock
@@ -2073,6 +2073,12 @@ dependencies = [
 [[package]]
 name = "solana-lints"
 version = "0.1.0"
+dependencies = [
+ "anchor-syn",
+ "clippy_utils",
+ "if_chain",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "solana-program"

--- a/lints/missing_owner_check/Cargo.lock
+++ b/lints/missing_owner_check/Cargo.lock
@@ -1682,11 +1682,13 @@ version = "0.1.0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
+ "anchor-syn",
  "clippy_utils",
  "dylint_linting",
  "dylint_testing",
  "if_chain",
  "solana-lints",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2413,6 +2415,12 @@ dependencies = [
 [[package]]
 name = "solana-lints"
 version = "0.1.0"
+dependencies = [
+ "anchor-syn",
+ "clippy_utils",
+ "if_chain",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "solana-logger"

--- a/lints/missing_owner_check/Cargo.toml
+++ b/lints/missing_owner_check/Cargo.toml
@@ -51,15 +51,7 @@ anchor-spl = "0.29"
 dylint_testing = "2.6"
 
 [workspace]
-# members = [
-#     "ui/*",
-# ]
 
 [package.metadata.rust-analyzer]
 rustc_private = true
 
-# [workspace.metadata.dylint]
-# libraries = [
-#     { path = "../solana-lints-dev", pattern = "lints/*" },
-#     # { git = "https://github.com/crytic/solana-lints", pattern = "lints/*" },
-# ]

--- a/lints/missing_owner_check/Cargo.toml
+++ b/lints/missing_owner_check/Cargo.toml
@@ -33,11 +33,17 @@ path = "ui/secure-account-owner/src/lib.rs"
 name = "secure-program-id"
 path = "ui/secure-program-id/src/lib.rs"
 
+[[example]]
+name = "secure-anchor-constraints"
+path = "ui/secure-anchor-constraints/src/lib.rs"
+
 [dependencies]
+anchor-syn = "0.29.0"
 clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "ac4c2094a6030530661bee3876e0228ddfeb6b8b" }
 dylint_linting = "2.6"
 if_chain = "1.0"
 solana-lints = { path = "../../crate" }
+syn = { version = "1.0.109", features = ["parsing"] }
 
 [dev-dependencies]
 anchor-lang = "0.29"
@@ -45,6 +51,15 @@ anchor-spl = "0.29"
 dylint_testing = "2.6"
 
 [workspace]
+# members = [
+#     "ui/*",
+# ]
 
 [package.metadata.rust-analyzer]
 rustc_private = true
+
+# [workspace.metadata.dylint]
+# libraries = [
+#     { path = "../solana-lints-dev", pattern = "lints/*" },
+#     # { git = "https://github.com/crytic/solana-lints", pattern = "lints/*" },
+# ]

--- a/lints/missing_owner_check/ui/secure-anchor-constraints/Cargo.toml
+++ b/lints/missing_owner_check/ui/secure-anchor-constraints/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "owner-checks-secure-anchor-constraints"
+version = "0.1.0"
+description = "Created with Anchor"
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "owner_checks_secure"
+
+[features]
+no-entrypoint = []
+no-idl = []
+no-log-ix-name = []
+cpi = ["no-entrypoint"]
+default = []
+
+[dependencies]
+anchor-lang = "0.29.0"
+
+[workspace]

--- a/lints/missing_owner_check/ui/secure-anchor-constraints/Xargo.toml
+++ b/lints/missing_owner_check/ui/secure-anchor-constraints/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/lints/missing_owner_check/ui/secure-anchor-constraints/src/lib.rs
+++ b/lints/missing_owner_check/ui/secure-anchor-constraints/src/lib.rs
@@ -1,0 +1,63 @@
+use anchor_lang::prelude::*;
+use anchor_lang::solana_program::entrypoint::ProgramResult;
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+fn check_accounts(accounts: &LogMessage) {
+    msg!("#[account(seeds)]: {}", accounts.canonical_pda.key());
+    msg!(
+        "#[account(address)]: {}",
+        accounts.address_acc.to_account_info().key()
+    );
+}
+
+#[program]
+pub mod owner_checks_secure {
+    use super::*;
+
+    pub fn log_message(ctx: Context<LogMessage>) -> ProgramResult {
+        msg!("#[account(signer)]: {}", ctx.accounts.authority.key());
+        msg!("#[account(init)]: {}", ctx.accounts.init_account.key());
+        msg!(
+            "#[account(owner)]: {}",
+            ctx.accounts.owner_acc.to_account_info().key()
+        );
+        msg!(
+            "#[account(executable)]: {}",
+            ctx.accounts.executable_acc.to_account_info().key()
+        );
+        check_accounts(ctx.accounts);
+        // Uncommenting the following line will fail the test.
+        // Lint reports this because constraints only check that the account is writable.
+        // msg!("#[account(mut)]: {}", ctx.accounts.receiver.key());
+        Ok(())
+    }
+}
+
+// close and realloc constraints require the type to be Account/AccountLoader
+// zero constraint just checks that discriminator is zero. doesn't seem to write to it. Lint should report this case.
+// init_if_needed constraint is reported by the lint.
+// Seems like spl constraints require the Account to be TokenAccount or Mint. Not considering them
+#[derive(Accounts)]
+pub struct LogMessage<'info> {
+    #[account(signer)]
+    pub authority: AccountInfo<'info>,
+    #[account(init, payer = payer, space = 8 + 8)]
+    pub init_account: AccountInfo<'info>,
+    #[account(seeds = [b"example_seed"], bump)]
+    pub canonical_pda: AccountInfo<'info>,
+    #[account(address = crate::ID)]
+    pub address_acc: UncheckedAccount<'info>,
+    #[account(owner = crate::ID)]
+    pub owner_acc: UncheckedAccount<'info>,
+    #[account(executable)]
+    pub executable_acc: UncheckedAccount<'info>,
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+    #[account(mut)]
+    pub receiver: AccountInfo<'info>,
+}
+
+#[allow(dead_code)]
+fn main() {}

--- a/lints/missing_signer_check/Cargo.lock
+++ b/lints/missing_signer_check/Cargo.lock
@@ -2073,6 +2073,12 @@ dependencies = [
 [[package]]
 name = "solana-lints"
 version = "0.1.0"
+dependencies = [
+ "anchor-syn",
+ "clippy_utils",
+ "if_chain",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "solana-program"

--- a/lints/type_cosplay/Cargo.lock
+++ b/lints/type_cosplay/Cargo.lock
@@ -2061,6 +2061,12 @@ dependencies = [
 [[package]]
 name = "solana-lints"
 version = "0.1.0"
+dependencies = [
+ "anchor-syn",
+ "clippy_utils",
+ "if_chain",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "solana-program"


### PR DESCRIPTION
The lint now checks if the AccountInfo expression accesses the field of a struct having `#[derive(Accounts)]` (Anchor Accounts structs). If so the lint checks for constraints applied on the field using `#[account(...)]`. The lint will *ignore* the expression if any of the constraints are applied on the field:

- `#[account(signer)]` - Signer accounts are assumed to be EOA accounts and are ignored.
- `#[account(init, ...)]` - init creates a new account and sets its owner to the current program or the given program.
- `#[account(seeds = ..., ...)]` - Anchor derives a PDA using the seeds. This is essentially a `key` check
- `#[account(address = ...)]` - Validates account's key.
- `#[account(owner = ...)]` - Validates the owner.
- `#[account(executable)]` - The account is an executable; All executables are owned by `BPFLoaders`.