### PR TITLE
Update Readme to contain Anchor and Non Anchor columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ The lints are inspired by the [Sealevel Attacks]. (See also @pencilflip's [Twitt
 
 The current lints are:
 
-| Library                                                          | Description                                                                                                                              |
-| ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| [`arbitrary_cpi`](lints/arbitrary_cpi)                           | lint for [5-arbitrary-cpi](https://github.com/coral-xyz/sealevel-attacks/tree/master/programs/5-arbitrary-cpi)                           |
-| [`bump_seed_canonicalization`](lints/bump_seed_canonicalization) | lint for [6-bump-seed-canonicalization](https://github.com/coral-xyz/sealevel-attacks/tree/master/programs/7-bump-seed-canonicalization) |
-| [`insecure_account_close`](lints/insecure_account_close)         | lint for [9-closing-accounts](https://github.com/coral-xyz/sealevel-attacks/tree/master/programs/9-closing-accounts)                     |
-| [`missing_owner_check`](lints/missing_owner_check)               | lint for [2-owner-checks](https://github.com/coral-xyz/sealevel-attacks/tree/master/programs/2-owner-checks)                             |
-| [`missing_signer_check`](lints/missing_signer_check)             | lint for [0-signer-authorization](https://github.com/coral-xyz/sealevel-attacks/tree/master/programs/0-signer-authorization)             |
-| [`sysvar_get`](lints/sysvar_get)                                 | Reports uses of `Sysvar::from_account_info` instead of `Sysvar::get`                                                                     |
-| [`type_cosplay`](lints/type_cosplay)                             | lint for [3-type-cosplay](https://github.com/coral-xyz/sealevel-attacks/tree/master/programs/3-type-cosplay)                             |
+| Library                                                          | Description                                                                                                                              | Anchor             | Non Anchor         |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------ | ------------------ |
+| [`arbitrary_cpi`](lints/arbitrary_cpi)                           | lint for [5-arbitrary-cpi](https://github.com/coral-xyz/sealevel-attacks/tree/master/programs/5-arbitrary-cpi)                           | :heavy_check_mark: | :heavy_check_mark: |
+| [`bump_seed_canonicalization`](lints/bump_seed_canonicalization) | lint for [6-bump-seed-canonicalization](https://github.com/coral-xyz/sealevel-attacks/tree/master/programs/7-bump-seed-canonicalization) |                    | :heavy_check_mark: |
+| [`insecure_account_close`](lints/insecure_account_close)         | lint for [9-closing-accounts](https://github.com/coral-xyz/sealevel-attacks/tree/master/programs/9-closing-accounts)                     | :heavy_check_mark: | :heavy_check_mark: |
+| [`missing_owner_check`](lints/missing_owner_check)               | lint for [2-owner-checks](https://github.com/coral-xyz/sealevel-attacks/tree/master/programs/2-owner-checks)                             | :heavy_check_mark: | :heavy_check_mark: |
+| [`missing_signer_check`](lints/missing_signer_check)             | lint for [0-signer-authorization](https://github.com/coral-xyz/sealevel-attacks/tree/master/programs/0-signer-authorization)             | :heavy_check_mark: | :heavy_check_mark: |
+| [`sysvar_get`](lints/sysvar_get)                                 | Reports uses of `Sysvar::from_account_info` instead of `Sysvar::get`                                                                     | :heavy_check_mark: | :heavy_check_mark: |
+| [`type_cosplay`](lints/type_cosplay)                             | lint for [3-type-cosplay](https://github.com/coral-xyz/sealevel-attacks/tree/master/programs/3-type-cosplay)                             |                    | :heavy_check_mark: |
 
 ## Usage
 

--- a/lints/arbitrary_cpi/README.md
+++ b/lints/arbitrary_cpi/README.md
@@ -6,6 +6,11 @@ Finds uses of solana_program::program::invoke that do not check the program_id
 **Why is this bad?**
 A contract could call into an attacker-controlled contract instead of the intended one
 
+**Works on:**
+
+- [x] Anchor
+- [x] Non Anchor
+
 **Known problems:**
 False positives, since the program_id check may be within some other function (does not
 trace through function calls)

--- a/lints/arbitrary_cpi/src/lib.rs
+++ b/lints/arbitrary_cpi/src/lib.rs
@@ -26,6 +26,11 @@ dylint_linting::declare_late_lint! {
     /// **Why is this bad?**
     /// A contract could call into an attacker-controlled contract instead of the intended one
     ///
+    /// **Works on:**
+    ///
+    /// - [x] Anchor
+    /// - [x] Non Anchor
+    ///
     /// **Known problems:**
     /// False positives, since the program_id check may be within some other function (does not
     /// trace through function calls)

--- a/lints/bump_seed_canonicalization/README.md
+++ b/lints/bump_seed_canonicalization/README.md
@@ -11,6 +11,11 @@ able to pick the bump_seed, since that would result in a different address.
 
 See https://github.com/crytic/building-secure-contracts/tree/master/not-so-smart-contracts/solana/improper_pda_validation
 
+**Works on:**
+
+- [ ] Anchor
+- [x] Non Anchor
+
 **Known problems:**
 
 False positives, since the bump_seed check may be within some other function (does not

--- a/lints/bump_seed_canonicalization/src/lib.rs
+++ b/lints/bump_seed_canonicalization/src/lib.rs
@@ -36,6 +36,11 @@ dylint_linting::declare_late_lint! {
     ///
     /// See https://github.com/crytic/building-secure-contracts/tree/master/not-so-smart-contracts/solana/improper_pda_validation
     ///
+    /// **Works on:**
+    ///
+    /// - [ ] Anchor
+    /// - [x] Non Anchor
+    ///
     /// **Known problems:**
     ///
     /// False positives, since the bump_seed check may be within some other function (does not

--- a/lints/insecure_account_close/README.md
+++ b/lints/insecure_account_close/README.md
@@ -11,6 +11,11 @@ See: https://docs.solana.com/developing/programming-model/transactions#multiple-
 
 > An example of where this could be a problem is if a token program, upon transferring the token out of an account, sets the account's lamports to zero, assuming it will be deleted by the runtime. If the program does not zero out the account's data, a malicious user could trail this instruction with another that transfers the tokens a second time.
 
+**Works on:**
+
+- [x] Anchor
+- [x] Non Anchor
+
 **Known problems:**
 
 None

--- a/lints/insecure_account_close/src/lib.rs
+++ b/lints/insecure_account_close/src/lib.rs
@@ -26,6 +26,11 @@ dylint_linting::declare_late_lint! {
     ///
     /// > An example of where this could be a problem is if a token program, upon transferring the token out of an account, sets the account's lamports to zero, assuming it will be deleted by the runtime. If the program does not zero out the account's data, a malicious user could trail this instruction with another that transfers the tokens a second time.
     ///
+    /// **Works on:**
+    ///
+    /// - [x] Anchor
+    /// - [x] Non Anchor
+    ///
     /// **Known problems:**
     ///
     /// None

--- a/lints/missing_owner_check/README.md
+++ b/lints/missing_owner_check/README.md
@@ -19,6 +19,11 @@ If no owner check is done on the account, then a malicious actor could pass in a
 account owned by some other program. The code may then perform some actions on the
 unauthorized account that is not owned by the SPL Token program.
 
+**Works on:**
+
+- [x] Anchor
+- [x] Non Anchor
+
 **Known problems:**
 
 Key checks can be strengthened. Currently, the lint only checks that the account's owner

--- a/lints/missing_owner_check/src/lib.rs
+++ b/lints/missing_owner_check/src/lib.rs
@@ -41,6 +41,11 @@ dylint_linting::impl_late_lint! {
     /// account owned by some other program. The code may then perform some actions on the
     /// unauthorized account that is not owned by the SPL Token program.
     ///
+    /// **Works on:**
+    ///
+    /// - [x] Anchor
+    /// - [x] Non Anchor
+    ///
     /// **Known problems:**
     ///
     /// Key checks can be strengthened. Currently, the lint only checks that the account's owner

--- a/lints/missing_signer_check/README.md
+++ b/lints/missing_signer_check/README.md
@@ -14,6 +14,11 @@ then anyone can create the instruction, call the program and perform a privilege
 For example if the Token program does not check that the owner of the tokens is a signer in the transfer instruction then anyone can
 transfer the tokens and steal them.
 
+**Works on:**
+
+- [x] Anchor
+- [x] Non Anchor
+
 **Known problems:**
 None.
 

--- a/lints/missing_signer_check/src/lib.rs
+++ b/lints/missing_signer_check/src/lib.rs
@@ -34,6 +34,11 @@ dylint_linting::impl_late_lint! {
     /// For example if the Token program does not check that the owner of the tokens is a signer in the transfer instruction then anyone can
     /// transfer the tokens and steal them.
     ///
+    /// **Works on:**
+    ///
+    /// - [x] Anchor
+    /// - [x] Non Anchor
+    ///
     /// **Known problems:**
     /// None.
     ///

--- a/lints/sysvar_get/README.md
+++ b/lints/sysvar_get/README.md
@@ -28,6 +28,11 @@ References:
 [`solana_program/sysvar` docs](https://docs.rs/solana-program/latest/solana_program/sysvar/index.html#:~:text=programs%20should%20prefer%20to%20call%20Sysvar%3A%3Aget),
 [Anchor docs](https://docs.rs/anchor-lang/latest/anchor_lang/accounts/sysvar/struct.Sysvar.html#:~:text=If%20possible%2C%20sysvars%20should%20not%20be%20used%20via%20accounts)
 
+**Works on:**
+
+- [x] Anchor
+- [x] Non Anchor
+
 **Known problems:**
 
 None

--- a/lints/sysvar_get/src/lib.rs
+++ b/lints/sysvar_get/src/lib.rs
@@ -48,6 +48,11 @@ dylint_linting::declare_late_lint! {
     /// [`solana_program/sysvar` docs](https://docs.rs/solana-program/latest/solana_program/sysvar/index.html#:~:text=programs%20should%20prefer%20to%20call%20Sysvar%3A%3Aget),
     /// [Anchor docs](https://docs.rs/anchor-lang/latest/anchor_lang/accounts/sysvar/struct.Sysvar.html#:~:text=If%20possible%2C%20sysvars%20should%20not%20be%20used%20via%20accounts)
     ///
+    /// **Works on:**
+    ///
+    /// - [x] Anchor
+    /// - [x] Non Anchor
+    ///
     /// **Known problems:**
     ///
     /// None

--- a/lints/type_cosplay/README.md
+++ b/lints/type_cosplay/README.md
@@ -27,6 +27,11 @@ tell the difference between deserialized type `X` and deserialized type `Y`. Thi
 malicious user to substitute `X` for `Y` or vice versa, and the code may perform unauthorized
 actions with the bytes.
 
+**Works on:**
+
+- [ ] Anchor
+- [x] Non Anchor
+
 **Known problems:**
 
 In the case when only one enum is deserialized, this lint by default

--- a/lints/type_cosplay/src/lib.rs
+++ b/lints/type_cosplay/src/lib.rs
@@ -53,6 +53,11 @@ dylint_linting::impl_late_lint! {
     /// malicious user to substitute `X` for `Y` or vice versa, and the code may perform unauthorized
     /// actions with the bytes.
     ///
+    /// **Works on:**
+    ///
+    /// - [ ] Anchor
+    /// - [x] Non Anchor
+    ///
     /// **Known problems:**
     ///
     /// In the case when only one enum is deserialized, this lint by default


### PR DESCRIPTION
Updated version of #90 

The support for anchor and non-anchor programs is extracted from the lint readmes instead of using package metadata in cargo.toml 